### PR TITLE
Add autocmd with arbitrary data for autocommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,24 @@ Replace `4001` with the port number you have set in the browser extension
 
 ## Custom settings according to website
 
-When you trigger GhostText, nvim-ghost triggers an `User` autocommand. You can
-listen for that autocommand and run your own commands (e.g. setting filetype)
-
-**NOTE:** All the autocommands should be in the `nvim_ghost_user_autocommands`
-augroup
-
+When you trigger GhostText, nvim-ghost triggers an `User` autocommand. You
+can either use `nvim_create_autocmd()` to listen for the `GhostTextAttach`
+pattern and retrieve the URL from the `data.url` callback parameter (Lua), or
+create an autocommand in the `nvim_ghost_user_autocommands` augroup and
+pattern match against the URL directly to set the filetype.
 Some examples -
+
+```lua
+vim.api.nvim_create_autocmd({ 'User' }, {
+  group = vim.api.nvim_create_augroup('NvimGhostText', { clear = true }),
+  pattern = {"GhostTextAttach"},
+  callback = function(ev)
+    if ev.data.url == "github.com" then
+      vim.o.filetype = "markdown"
+    end
+  end,
+})
+```
 
 ```vim
 " Autocommand for a single website (i.e. stackoverflow.com)

--- a/binary.py
+++ b/binary.py
@@ -444,6 +444,12 @@ class GhostWebSocket(WebSocket):
 
     def _trigger_autocmds(self, url: str):
         self.neovim_handle.command(f"doau nvim_ghost_user_autocommands User {url}")
+        self.neovim_handle.api.exec_autocmds("User", {
+            "pattern": "GhostTextAttach",
+            "data": {
+                "url": url
+            }
+        })
 
     def _do_close(self):
         log(


### PR DESCRIPTION
I wanted to use autocmd to trigger specific actions when GhostText was
activated (namely focus my Neovide instance), and creating an autocmd using `au
nvim_ghost_user_autocommands User * ! open -a iTerm` was too broad, as it would
trigger for any User event defined by other plugins.

So I created a new autocmd that is then triggered with `nvim_exec_autocmd`, but
passing the url via the `data` callback property, only available in the
`nvim_create_autocmd` function call. It's notably more useful when writing
config files in Lua.